### PR TITLE
add eruby to default mta_filetypes

### DIFF
--- a/plugin/MatchTagAlways.vim
+++ b/plugin/MatchTagAlways.vim
@@ -33,6 +33,7 @@ let g:mta_filetypes =
       \ 'xhtml' : 1,
       \ 'xml' : 1,
       \ 'jinja' : 1,
+      \ 'eruby' : 1,
       \} )
 
 let g:mta_use_matchparen_group =


### PR DESCRIPTION
I think given alot of people edit .erb files, this could save a lot of people time by not having to override the default options to add it. If you don't feel like adding more defaults, that's ok too. :smiley:
