### PR TITLE
Allow "MatchTagAlways" to work when vim is compiled with Python3 support...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
 script: nosetests

--- a/autoload/MatchTagAlways.vim
+++ b/autoload/MatchTagAlways.vim
@@ -17,10 +17,19 @@
 
 
 let s:script_folder_path = escape( expand( '<sfile>:p:h' ), '\' )
-py import sys
-py import vim
-exe 'python sys.path = sys.path + ["' . s:script_folder_path . '/../python"]'
-py import mta_vim
+if has('python')
+    " Python 2
+    py import sys
+    py import vim
+    exe 'python sys.path = sys.path + ["' . s:script_folder_path . '/../python"]'
+    py import mta_vim
+else
+    " Python 3
+    py3 import sys
+    py3 import vim
+    exe 'python3 sys.path = sys.path + ["' . s:script_folder_path . '/../python"]'
+    py3 import mta_vim
+endif
 
 
 if g:mta_use_matchparen_group
@@ -70,10 +79,18 @@ endfunction
 
 function! s:GetEnclosingTagLocations()
   " Sadly, pyeval does not exist before Vim 7.3.584
-  if v:version >= 703 && has( 'patch584' )
-    return pyeval( 'mta_vim.LocationOfEnclosingTagsInWindowView()' )
+  if has('python')
+    if v:version >= 703 && has( 'patch584' )
+      return pyeval( 'mta_vim.LocationOfEnclosingTagsInWindowView()' )
+    else
+      py vim.command( 'return ' + str( mta_vim.LocationOfEnclosingTagsInWindowView() ) )
+    endif
   else
-    py vim.command( 'return ' + str( mta_vim.LocationOfEnclosingTagsInWindowView() ) )
+    if v:version >= 703 && has( 'patch584' )
+      return py3eval( 'mta_vim.LocationOfEnclosingTagsInWindowView()' )
+    else
+      py3 vim.command( 'return ' + str( mta_vim.LocationOfEnclosingTagsInWindowView() ) )
+    endif
   endif
 endfunction
 

--- a/plugin/MatchTagAlways.vim
+++ b/plugin/MatchTagAlways.vim
@@ -20,9 +20,9 @@ if exists( "g:loaded_matchtagalways" )
 endif
 let g:loaded_matchtagalways = 1
 
-if !has( 'python' )
+if !( has( 'python' ) || has( 'python3' ) )
   echohl WarningMsg |
-        \ echomsg "MatchTagAlways unavailable: requires python 2.x" |
+        \ echomsg "MatchTagAlways unavailable: requires python." |
         \ echohl None
   finish
 endif

--- a/python/mta_core.py
+++ b/python/mta_core.py
@@ -17,8 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with MatchTagAlways.  If not, see <http://www.gnu.org/licenses/>.
 
+import sys
 import re
 
+PY2 = (sys.version_info[0] == 2)
 
 TAG_REGEX = re.compile(
   r"""<\s*                    # the opening bracket + whitespace
@@ -58,8 +60,12 @@ class Tag( object ):
     self.end_offset = match_object.end()
 
 
-  def __nonzero__( self ):
-    return self.valid
+  if PY2:
+    def __nonzero__( self ):
+      return self.valid
+  else:
+    def __bool__( self ):
+      return self.valid
 
 
   def __eq__( self, other ):

--- a/python/tests/mta_core_test.py
+++ b/python/tests/mta_core_test.py
@@ -17,9 +17,16 @@
 # You should have received a copy of the GNU General Public License
 # along with MatchTagAlways.  If not, see <http://www.gnu.org/licenses/>.
 
+# Python 3 compatibility
+import sys
+PY2 = (sys.version_info[0] == 2)
+if PY2:
+  range = xrange
+
+
+# imports
 from nose.tools import eq_
 from .. import mta_core
-
 
 def LineColumnOffsetConversions_Basic_test():
   text = "foo"
@@ -266,7 +273,7 @@ def LocationsOfEnclosingTags_CursorInTagFull_test():
   def gen( column ):
     eq_( ( 1, 1, 1, 6 ), mta_core.LocationsOfEnclosingTags( html, 1, column ) )
 
-  for i in xrange( 1, len( html ) + 1 ):
+  for i in range( 1, len( html ) + 1 ):
     yield gen, i
 
 
@@ -290,7 +297,7 @@ def LocationsOfEnclosingTags_UnbalancedOpeningTagFull_test():
   def gen( column ):
     eq_( ( 1, 1, 1, 12 ), mta_core.LocationsOfEnclosingTags( html, 1, column ) )
 
-  for i in xrange( 1, len( html ) + 1 ):
+  for i in range( 1, len( html ) + 1 ):
     yield gen, i
 
 


### PR DESCRIPTION
Allow "MatchTagAlways" to work when vim is compiled with Python3 support.

Note: I am not really sure if I've implemented this with the optimal way
because I have no experience with VIMScript, but the tests pass on both
Python versions and as far as I've checked, everything seems to work fine.
