### PR TITLE
Adding a check for python on load

### DIFF
--- a/plugin/MatchTagAlways.vim
+++ b/plugin/MatchTagAlways.vim
@@ -15,7 +15,7 @@
 " You should have received a copy of the GNU General Public License
 " along with MatchTagAlways.  If not, see <http://www.gnu.org/licenses/>.
 
-if exists( "g:loaded_matchtagalways" )
+if exists( "g:loaded_matchtagalways" ) || !has('python')
   finish
 endif
 let g:loaded_matchtagalways = 1


### PR DESCRIPTION
This way the plugin will quietly fail to load rather than declaring an error each time vim is started.
