### PR TITLE
Added go to closing tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ Default: `1`
 
     let g:mta_set_default_matchtag_color = 1
 
+## Comands
+
+You can use the plugin to also go to the closing tag if this tag is in the
+visible screen. 
+
+### `MtaJumpToOtherTag`
+
+Jumps to the enclosing tag if the tag is visible. If you are on top of an
+opening tag, it will jump to the closing tag. If you are on the closing tag,
+it will jump to the opening tag. If you are inside a tag, then it will jump to
+the closing tag. 
+
+Setting a mapping for this command: 
+
+    `nmap <leader>% :MtaJumpToOtherTag<cr>`
+
 ## FAQ
 
 ### I've noticed that sometimes no tags are highlighted. Why?

--- a/autoload/MatchTagAlways.vim
+++ b/autoload/MatchTagAlways.vim
@@ -58,6 +58,7 @@ function! MatchTagAlways#Setup()
   if !g:mta_use_matchparen_group && g:mta_set_default_matchtag_color
     hi MatchTag ctermfg=black ctermbg=lightblue guifg=black guibg=lightblue
   endif
+  execute "nmap " . g:Mta_goto_enclosing_tag_map . " :call MatchTagAlways#GoToEnclosingTag()<cr>"
 endfunction
 
 
@@ -92,6 +93,38 @@ function! s:GetEnclosingTagLocations()
       py3 vim.command( 'return ' + str( mta_vim.LocationOfEnclosingTagsInWindowView() ) )
     endif
   endif
+endfunction
+
+function! MatchTagAlways#GoToEnclosingTag()
+  let [ opening_tag_line, opening_tag_column, closing_tag_line, closing_tag_column ] =
+        \ s:GetEnclosingTagLocations()
+  let first_window_line = line( 'w0' )
+
+  if opening_tag_line < first_window_line
+    return
+  endif
+
+  let pos = getpos('.')
+  let current_line = pos[1]
+  let current_column = pos[2]
+
+  if (closing_tag_line == opening_tag_line)
+	  if current_column >= closing_tag_column
+		  let line = opening_tag_line
+		  let column = opening_tag_column
+	  else
+		  let line = closing_tag_line
+		  let column = closing_tag_column
+	  endif
+  elseif current_line == closing_tag_line
+	  let line = opening_tag_line
+	  let column = opening_tag_column
+  else
+	  let line = closing_tag_line
+	  let column = closing_tag_column
+  endif
+
+  call cursor(line, column)
 endfunction
 
 

--- a/autoload/MatchTagAlways.vim
+++ b/autoload/MatchTagAlways.vim
@@ -108,19 +108,19 @@ function! MatchTagAlways#GoToEnclosingTag()
   let current_column = pos[2]
 
   if (closing_tag_line == opening_tag_line)
-	  if current_column >= closing_tag_column
-		  let line = opening_tag_line
-		  let column = opening_tag_column
-	  else
-		  let line = closing_tag_line
-		  let column = closing_tag_column
-	  endif
+    if current_column >= closing_tag_column
+      let line = opening_tag_line
+      let column = opening_tag_column
+    else
+      let line = closing_tag_line
+      let column = closing_tag_column
+    endif
   elseif current_line == closing_tag_line
-	  let line = opening_tag_line
-	  let column = opening_tag_column
+    let line = opening_tag_line
+    let column = opening_tag_column
   else
-	  let line = closing_tag_line
-	  let column = closing_tag_column
+    let line = closing_tag_line
+    let column = closing_tag_column
   endif
 
   call cursor(line, column)

--- a/autoload/MatchTagAlways.vim
+++ b/autoload/MatchTagAlways.vim
@@ -58,7 +58,6 @@ function! MatchTagAlways#Setup()
   if !g:mta_use_matchparen_group && g:mta_set_default_matchtag_color
     hi MatchTag ctermfg=black ctermbg=lightblue guifg=black guibg=lightblue
   endif
-  execute "nmap " . g:Mta_goto_enclosing_tag_map . " :call MatchTagAlways#GoToEnclosingTag()<cr>"
 endfunction
 
 

--- a/plugin/MatchTagAlways.vim
+++ b/plugin/MatchTagAlways.vim
@@ -42,9 +42,8 @@ let g:mta_use_matchparen_group =
       \ get( g:, 'mta_use_matchparen_group', 1 )
 let g:mta_set_default_matchtag_color =
       \ get( g:, 'mta_set_default_matchtag_color', 1 )
-if !exists('g:Mta_goto_enclosing_tag_map')
-	let g:Mta_goto_enclosing_tag_map = '<leader>%'
-endif
+
+command -nargs=0 MtaJumpToOtherTag call MatchTagAlways#GoToEnclosingTag()
 
 augroup matchtagalways
   autocmd! FileType * call MatchTagAlways#Setup()

--- a/plugin/MatchTagAlways.vim
+++ b/plugin/MatchTagAlways.vim
@@ -42,6 +42,9 @@ let g:mta_use_matchparen_group =
       \ get( g:, 'mta_use_matchparen_group', 1 )
 let g:mta_set_default_matchtag_color =
       \ get( g:, 'mta_set_default_matchtag_color', 1 )
+if !exists('g:Mta_goto_enclosing_tag_map')
+	let g:Mta_goto_enclosing_tag_map = '<leader>%'
+endif
 
 augroup matchtagalways
   autocmd! FileType * call MatchTagAlways#Setup()


### PR DESCRIPTION
Added the option to go to the closing tag if it's visible on screen. I've also added the possibility to set a shortcut through vimrc. I've put a capital letter on the variable (Mta_goto_enclosing_tag_map) so that it can survive a session save and restore. The default mapping is `<leader>%`