### PR TITLE
Remove redundant check for python support

### DIFF
--- a/plugin/MatchTagAlways.vim
+++ b/plugin/MatchTagAlways.vim
@@ -15,7 +15,7 @@
 " You should have received a copy of the GNU General Public License
 " along with MatchTagAlways.  If not, see <http://www.gnu.org/licenses/>.
 
-if exists( "g:loaded_matchtagalways" ) || !has('python')
+if exists( "g:loaded_matchtagalways" )
   finish
 endif
 let g:loaded_matchtagalways = 1


### PR DESCRIPTION
The check for python in line 18 is incomplete as it checks only for python2 whereas the plugin clearly supports python3. For those of us who have python3 support but not python2, your plugin doesn't load. Besides, python support is being checked for, with a helpful error message in the next code block.