### PR TITLE
Update tag highlight group pattern

### DIFF
--- a/autoload/MatchTagAlways.vim
+++ b/autoload/MatchTagAlways.vim
@@ -137,7 +137,7 @@ function! s:HighlightEnclosingTags()
   endif
 
   exe '2match ' . s:match_group . ' /' .
-        \ '\(\%' . opening_tag_line . 'l\%' . opening_tag_column . 'c<\/\?\_s*\zs.\{-}\ze[ >\/]\)\|' .
+        \ '\(\%' . opening_tag_line . 'l\%' . opening_tag_column . 'c<\/\?\_s*\zs.\{-}\ze[ >\/\n]\)\|' .
         \ '\(\%' . closing_tag_line . 'l\%' . closing_tag_column . 'c<\/\?\_s*\zs.\{-}\ze[ >\/]\)' .
         \ '/'
   let w:tags_highlighted = 1


### PR DESCRIPTION
previous pattern does't support tag attributes multi-line display,
especially in jsx. highlight of start tag(ParentComponent) disappear

```html
<ParentComponent
  foo={"foo"}
  bar={false}
>
  <ChildComponent />
</ParentComponent>
```